### PR TITLE
Component list and incident list methods should allow params

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ get/ping   | CachetClient.ping | N/A            |
 
 Cachet API                   | Ruby Library                    | Options/Params (R) == Required
 :--------------------------- | :------------------------------ | :-------------------------------------------------------------------------------
-get/components               | CachetComponents.list           | N/A                                                                              |
+get/components               | CachetComponents.list           | Options (hash) : id, name, status, group_id, enabled                             |
 get/components/:id           | CachetComponents.list_id        | Options (hash) : id                                                              |
 post/components              | CachetComponents.create         | Options (hash) : name(R), status(R), description, link, order, group_id, enabled |
 put/components/:id           | CachetComponents.update         | Options (hash) : id(R), status(R), name(R), link, order, group_id, enabled       |
@@ -66,7 +66,7 @@ delete/components/groups/:id | CachetComponents.groups_delete  | Options (hash) 
 
 Cachet API           | Ruby Library            | Options/Params (R) == Required
 :------------------- | :---------------------- | :--------------------------------------------------------------------------------------------------
-get/incidents        | CachetIncidents.list    | N/A                                                                                                 |
+get/incidents        | CachetIncidents.list    | Options (hash) : id, component_id, name, status, visible                                            |
 get/incidents/:id    | CachetIncidents.list_id | Options (hash) : id                                                                                 |
 post/incidents       | CachetIncidents.create  | Options (hash) : name(R), message(R), status(R), visible(R), component_id, component_status, notify |
 put/incidents/:id    | CachetIncidents.update  | Options (hash) : id(R), name, message, status, visible, component_id, component_status, notify      |

--- a/lib/cachet.rb
+++ b/lib/cachet.rb
@@ -66,7 +66,8 @@ class CachetClient
   # @return object
 
   def request(params)
-    response = RestClient::Request.execute(params.merge(headers: @headers))
+    headers = params[:headers] ? @headers.merge(params[:headers]) : @headers
+    response = RestClient::Request.execute(params.merge(headers: headers))
     code = response.code
 
     if response.code == 200
@@ -99,9 +100,10 @@ class CachetComponents < CachetClient
   #
   # @return object
 
-  def list
+  def list(options = nil)
     request method:  :get,
-            url:     @base_url + 'components'
+            url:     @base_url + 'components',
+            headers: {params: options}
   end
 
   ##
@@ -232,9 +234,10 @@ class CachetIncidents < CachetClient
   #
   # @return object
 
-  def list
+  def list(options = nil)
     request method:  :get,
-            url:     @base_url + 'incidents'
+            url:     @base_url + 'incidents',
+            headers: {params: options}
   end
 
   ##

--- a/spec/cachet_components_spec.rb
+++ b/spec/cachet_components_spec.rb
@@ -30,6 +30,13 @@ describe CachetComponents do
       components_list_response['data'][0]['id'].should_not be nil
     end
 
+    ## Test CachetComponents.list with options
+    components_list_response = CachetComponents.list(status: CachetClient::STATUS_OPERATIONAL)
+    it 'should accept params and return component list, assign to variable, and variable should return data' do
+      components_list_response.should_not be nil
+      components_list_response['data'][0]['id'].should_not be nil
+    end
+
     ## Test CachetComponents.list_id
     options_component_list_id = {}
     options_component_list_id['id'] = components_create_response['data']['id']

--- a/spec/cachet_incidents_spec.rb
+++ b/spec/cachet_incidents_spec.rb
@@ -32,6 +32,13 @@ describe CachetIncidents do
       incidents_list_response['data'][0]['id'].should_not be nil
     end
 
+    ## Test CachetIncidents.list with options
+    incidents_list_response = CachetIncidents.list({status: CachetClient::INCIDENT_INVESTIGATING })
+    it 'should accept params and return incident list, assign to variable, and variable should return data' do
+      incidents_list_response.should_not be nil
+      incidents_list_response['data'][0]['id'].should_not be nil
+    end
+
     ## Test CachetIncidents.list_id
     options_incident_list_id = {}
     options_incident_list_id['id'] = incidents_create_response['data']['id']


### PR DESCRIPTION
This PR allows params on **incidents** and **components**

``` ruby
CachetIncidents.list(status: 2)

CachetComponents.list(name: 'My Component')
```
